### PR TITLE
Fix the prerequisite golang version typo

### DIFF
--- a/example/run/README.md
+++ b/example/run/README.md
@@ -97,7 +97,7 @@ docker run -e KUBECONFIG=/mnt/.kube/config \
 
 **Prerequisite**
 
-Ensure you have installed [Golang 10.10 or above](https://golang.org/doc/install#install) and the [${GOPATH}](https://golang.org/doc/code.html#GOPATH) is valid.
+Ensure you have installed [Golang 1.10 or above](https://golang.org/doc/install#install) and the [${GOPATH}](https://golang.org/doc/code.html#GOPATH) is valid.
 
 Then build the FrameworkController binary distribution:
 ```shell


### PR DESCRIPTION
Fix: https://github.com/Microsoft/frameworkcontroller/issues/4