### PR TITLE
[BREAKING CHANGE]: Refine AnnotationKey, LabelKey and EnvName

### DIFF
--- a/example/framework/basic/batchstatefulfailed.yaml
+++ b/example/framework/basic/batchstatefulfailed.yaml
@@ -27,18 +27,19 @@ spec:
             # To locate a specific Task during its whole lifecycle regardless of
             # any retry:
             # Consistent Identity:
-            # PodName = {FrameworkName}-{TaskRoleName}-{TaskIndex}
             # PodNamespace = {FrameworkNamespace}
+            # PodName = {FrameworkName}-{TaskRoleName}-{TaskIndex}
             # Consistent Environment Variable Value:
-            # ${FRAMEWORK_NAME}, ${TASKROLE_NAME}, ${TASK_INDEX}
-            # ${CONFIGMAP_NAME}, ${POD_NAME}, ${POD_NAMESPACE}
+            # ${FC_FRAMEWORK_NAMESPACE},
+            # ${FC_FRAMEWORK_NAME}, ${FC_TASKROLE_NAME}, ${FC_TASK_INDEX},
+            # ${FC_CONFIGMAP_NAME}, ${FC_POD_NAME}
             #
             # To locate a specific execution attempt of a specific Task:
             # Attempt Specific Environment Variable Value:
-            # ${FRAMEWORK_ATTEMPT_ID}, ${TASK_ATTEMPT_ID}
+            # ${FC_FRAMEWORK_ATTEMPT_ID}, ${FC_TASK_ATTEMPT_ID}
             #
             # To locate a specific execution attempt instance of a specific Task:
             # Attempt Instance Specific Environment Variable Value:
-            # ${FRAMEWORK_ATTEMPT_INSTANCE_UID}, ${CONFIGMAP_UID}
-            # ${TASK_ATTEMPT_INSTANCE_UID}, ${POD_UID}
+            # ${FC_FRAMEWORK_ATTEMPT_INSTANCE_UID}, ${FC_CONFIGMAP_UID}
+            # ${FC_TASK_ATTEMPT_INSTANCE_UID}, ${FC_POD_UID}
             command: ["sh", "-c", "printenv && sleep 60 && exit 1"]

--- a/example/framework/basic/service.yaml
+++ b/example/framework/basic/service.yaml
@@ -38,8 +38,8 @@ metadata:
 spec:
   selector:
     # Using predefined labels
-    FRAMEWORK_NAME: service
-    TASKROLE_NAME: server
+    FC_FRAMEWORK_NAME: service
+    FC_TASKROLE_NAME: server
     # Also can use customized labels
     #app: server
   ports:

--- a/example/framework/basic/servicestateful.yaml
+++ b/example/framework/basic/servicestateful.yaml
@@ -43,8 +43,8 @@ metadata:
 spec:
   selector:
     # See comments in service.yaml
-    FRAMEWORK_NAME: servicestateful
-    TASKROLE_NAME: serverstateful
+    FC_FRAMEWORK_NAME: servicestateful
+    FC_TASKROLE_NAME: serverstateful
   ports:
   - port: 80
   type: NodePort

--- a/example/framework/extension/frameworkbarrier.yaml
+++ b/example/framework/extension/frameworkbarrier.yaml
@@ -29,15 +29,15 @@ spec:
           containers:
           - name: ubuntu
             image: ubuntu:trusty
-            # Using /mnt/frameworkbarrier/injector.sh to inject environment
-            # variables, such as:
-            # {TaskRoleName}_ips=
+            # Using /mnt/frameworkbarrier/injector.sh to inject environment variables,
+            # such as:
+            # FB_{UpperCase({TaskRoleName})}_IPS=
             #   {Task[0].PodIP},...,
             #   {Task[TaskRole.TaskNumber-1].PodIP}
-            # {TaskRoleName}_addresses=
-            #   {Task[0].PodIP}:${{TaskRoleName}_port},...,
-            #   {Task[TaskRole.TaskNumber-1].PodIP}:${{TaskRoleName}_port}
-            #  Note, the environment variable {TaskRoleName}_port should be
+            # FB_{UpperCase({TaskRoleName})}_ADDRESSES=
+            #   {Task[0].PodIP}:${FB_{UpperCase({TaskRoleName})}_PORT},...,
+            #   {Task[TaskRole.TaskNumber-1].PodIP}:${FB_{UpperCase({TaskRoleName})}_PORT}
+            #  Note, the environment variable FB_{UpperCase({TaskRoleName})}_PORT should be
             #  provided by the caller in advance.
             #
             # User may need to tweak these environment variables to its own
@@ -48,8 +48,8 @@ spec:
             # /mnt/frameworkbarrier/framework.json.
             command: [
             "sh", "-c",
-            "server_port=4001 worker_port=5001 . /mnt/frameworkbarrier/injector.sh && printenv &&
-            server_port=4002 worker_port=5002 . /mnt/frameworkbarrier/injector.sh && printenv &&
+            "FB_SERVER_PORT=4001 FB_WORKER_PORT=5001 . /mnt/frameworkbarrier/injector.sh && printenv &&
+            FB_SERVER_PORT=4002 FB_WORKER_PORT=5002 . /mnt/frameworkbarrier/injector.sh && printenv &&
             sleep 60"]
             ports:
             - containerPort: 4001
@@ -104,8 +104,8 @@ spec:
             image: ubuntu:trusty
             command: [
             "sh", "-c",
-            "server_port=4001 worker_port=5001 . /mnt/frameworkbarrier/injector.sh && printenv &&
-            server_port=4002 worker_port=5002 . /mnt/frameworkbarrier/injector.sh && printenv &&
+            "FB_SERVER_PORT=4001 FB_WORKER_PORT=5001 . /mnt/frameworkbarrier/injector.sh && printenv &&
+            FB_SERVER_PORT=4002 FB_WORKER_PORT=5002 . /mnt/frameworkbarrier/injector.sh && printenv &&
             sleep 60"]
             ports:
             - containerPort: 5001

--- a/example/framework/scenario/tensorflow/cpu/tensorflowdistributedtrainingwithcpu.yaml
+++ b/example/framework/scenario/tensorflow/cpu/tensorflowdistributedtrainingwithcpu.yaml
@@ -43,22 +43,22 @@ spec:
             # For the tf_cnn_benchmarks usage, see
             # https://github.com/tensorflow/benchmarks/tree/master/scripts/tf_cnn_benchmarks
             workingDir: /tensorflow/benchmarks/scripts/tf_cnn_benchmarks
-            # Using /mnt/frameworkbarrier/injector.sh to inject environment
-            # variables without the need for image invasion and k8s DNS:
-            # {TaskRoleName}_addresses=
-            #   {Task[0].PodIP}:${{TaskRoleName}_port},...,
-            #   {Task[TaskRole.TaskNumber-1].PodIP}:${{TaskRoleName}_port}
+            # Using /mnt/frameworkbarrier/injector.sh to inject environment variables
+            # without the need for image invasion and k8s DNS:
+            # FB_{UpperCase({TaskRoleName})}_ADDRESSES=
+            #   {Task[0].PodIP}:${FB_{UpperCase({TaskRoleName})}_PORT},...,
+            #   {Task[TaskRole.TaskNumber-1].PodIP}:${FB_{UpperCase({TaskRoleName})}_PORT}
             # See more in ./example/framework/extension/frameworkbarrier.yaml
             command: [
             "sh", "-c",
-            "ps_port=4001 worker_port=5001 . /mnt/frameworkbarrier/injector.sh &&
-            python tf_cnn_benchmarks.py --job_name=ps --task_index=${TASK_INDEX}
-            --ps_hosts=${ps_addresses} --worker_hosts=${worker_addresses}
+            "FB_PS_PORT=4001 FB_WORKER_PORT=5001 . /mnt/frameworkbarrier/injector.sh &&
+            python tf_cnn_benchmarks.py --job_name=ps --task_index=${FC_TASK_INDEX}
+            --ps_hosts=${FB_PS_ADDRESSES} --worker_hosts=${FB_WORKER_ADDRESSES}
             --variable_update=parameter_server --cross_replica_sync=false
             --model=alexnet --batch_size=8 --num_batches=10
             --device=cpu --local_parameter_device=cpu --data_format=NHWC
             --data_name=cifar10 --data_dir=/mnt/data/cifar-10-batches-py
-            --train_dir=/mnt/data/${FRAMEWORK_NAME}/output"]
+            --train_dir=/mnt/data/${FC_FRAMEWORK_NAME}/output"]
             ports:
             - containerPort: 4001
             volumeMounts:
@@ -129,14 +129,14 @@ spec:
             workingDir: /tensorflow/benchmarks/scripts/tf_cnn_benchmarks
             command: [
             "sh", "-c",
-            "ps_port=4001 worker_port=5001 . /mnt/frameworkbarrier/injector.sh &&
-            python tf_cnn_benchmarks.py --job_name=worker --task_index=${TASK_INDEX}
-            --ps_hosts=${ps_addresses} --worker_hosts=${worker_addresses}
+            "FB_PS_PORT=4001 FB_WORKER_PORT=5001 . /mnt/frameworkbarrier/injector.sh &&
+            python tf_cnn_benchmarks.py --job_name=worker --task_index=${FC_TASK_INDEX}
+            --ps_hosts=${FB_PS_ADDRESSES} --worker_hosts=${FB_WORKER_ADDRESSES}
             --variable_update=parameter_server --cross_replica_sync=false
             --model=alexnet --batch_size=8 --num_batches=10
             --device=cpu --local_parameter_device=cpu --data_format=NHWC
             --data_name=cifar10 --data_dir=/mnt/data/cifar-10-batches-py
-            --train_dir=/mnt/data/${FRAMEWORK_NAME}/output"]
+            --train_dir=/mnt/data/${FC_FRAMEWORK_NAME}/output"]
             ports:
             - containerPort: 5001
             volumeMounts:

--- a/example/framework/scenario/tensorflow/gpu/tensorflowdistributedtrainingwithgpu.yaml
+++ b/example/framework/scenario/tensorflow/gpu/tensorflowdistributedtrainingwithgpu.yaml
@@ -43,22 +43,22 @@ spec:
             # For the tf_cnn_benchmarks usage, see
             # https://github.com/tensorflow/benchmarks/tree/master/scripts/tf_cnn_benchmarks
             workingDir: /tensorflow/benchmarks/scripts/tf_cnn_benchmarks
-            # Using /mnt/frameworkbarrier/injector.sh to inject environment
-            # variables without the need for image invasion and k8s DNS:
-            # {TaskRoleName}_addresses=
-            #   {Task[0].PodIP}:${{TaskRoleName}_port},...,
-            #   {Task[TaskRole.TaskNumber-1].PodIP}:${{TaskRoleName}_port}
+            # Using /mnt/frameworkbarrier/injector.sh to inject environment variables
+            # without the need for image invasion and k8s DNS:
+            # FB_{UpperCase({TaskRoleName})}_ADDRESSES=
+            #   {Task[0].PodIP}:${FB_{UpperCase({TaskRoleName})}_PORT},...,
+            #   {Task[TaskRole.TaskNumber-1].PodIP}:${FB_{UpperCase({TaskRoleName})}_PORT}
             # See more in ./example/framework/extension/frameworkbarrier.yaml
             command: [
             "sh", "-c",
-            "ps_port=4001 worker_port=5001 . /mnt/frameworkbarrier/injector.sh &&
-            python tf_cnn_benchmarks.py --job_name=ps --task_index=${TASK_INDEX}
-            --ps_hosts=${ps_addresses} --worker_hosts=${worker_addresses}
+            "FB_PS_PORT=4001 FB_WORKER_PORT=5001 . /mnt/frameworkbarrier/injector.sh &&
+            python tf_cnn_benchmarks.py --job_name=ps --task_index=${FC_TASK_INDEX}
+            --ps_hosts=${FB_PS_ADDRESSES} --worker_hosts=${FB_WORKER_ADDRESSES}
             --variable_update=parameter_server --cross_replica_sync=false
             --model=alexnet --batch_size=8 --num_batches=10
             --device=gpu --local_parameter_device=gpu --num_gpus=1 --data_format=NCHW
             --data_name=cifar10 --data_dir=/mnt/data/cifar-10-batches-py
-            --train_dir=/mnt/data/${FRAMEWORK_NAME}/output"]
+            --train_dir=/mnt/data/${FC_FRAMEWORK_NAME}/output"]
             ports:
             - containerPort: 4001
             resources:
@@ -135,14 +135,14 @@ spec:
             workingDir: /tensorflow/benchmarks/scripts/tf_cnn_benchmarks
             command: [
             "sh", "-c",
-            "ps_port=4001 worker_port=5001 . /mnt/frameworkbarrier/injector.sh &&
-            python tf_cnn_benchmarks.py --job_name=worker --task_index=${TASK_INDEX}
-            --ps_hosts=${ps_addresses} --worker_hosts=${worker_addresses}
+            "FB_PS_PORT=4001 FB_WORKER_PORT=5001 . /mnt/frameworkbarrier/injector.sh &&
+            python tf_cnn_benchmarks.py --job_name=worker --task_index=${FC_TASK_INDEX}
+            --ps_hosts=${FB_PS_ADDRESSES} --worker_hosts=${FB_WORKER_ADDRESSES}
             --variable_update=parameter_server --cross_replica_sync=false
             --model=alexnet --batch_size=8 --num_batches=10
             --device=gpu --local_parameter_device=gpu --num_gpus=1 --data_format=NCHW
             --data_name=cifar10 --data_dir=/mnt/data/cifar-10-batches-py
-            --train_dir=/mnt/data/${FRAMEWORK_NAME}/output"]
+            --train_dir=/mnt/data/${FC_FRAMEWORK_NAME}/output"]
             ports:
             - containerPort: 5001
             resources:

--- a/pkg/apis/frameworkcontroller/v1/constants.go
+++ b/pkg/apis/frameworkcontroller/v1/constants.go
@@ -46,35 +46,40 @@ const (
 	ExtendedUnlimitedValue = -2
 
 	// For all managed objects
-	AnnotationKeyFrameworkName = "FRAMEWORK_NAME"
-	AnnotationKeyTaskRoleName  = "TASKROLE_NAME"
-	AnnotationKeyTaskIndex     = "TASK_INDEX"
-	AnnotationKeyConfigMapName = "CONFIGMAP_NAME"
-	AnnotationKeyPodName       = "POD_NAME"
-	AnnotationKeyPodNamespace  = "POD_NAMESPACE"
+	// Predefined Annotations
+	AnnotationKeyFrameworkNamespace = "FC_FRAMEWORK_NAMESPACE"
+	AnnotationKeyFrameworkName      = "FC_FRAMEWORK_NAME"
+	AnnotationKeyTaskRoleName       = "FC_TASKROLE_NAME"
+	AnnotationKeyTaskIndex          = "FC_TASK_INDEX"
+	AnnotationKeyConfigMapName      = "FC_CONFIGMAP_NAME"
+	AnnotationKeyPodName            = "FC_POD_NAME"
 
-	AnnotationKeyFrameworkAttemptID          = "FRAMEWORK_ATTEMPT_ID"
-	AnnotationKeyFrameworkAttemptInstanceUID = "FRAMEWORK_ATTEMPT_INSTANCE_UID"
-	AnnotationKeyConfigMapUID                = "CONFIGMAP_UID"
-	AnnotationKeyTaskAttemptID               = "TASK_ATTEMPT_ID"
+	AnnotationKeyFrameworkAttemptID          = "FC_FRAMEWORK_ATTEMPT_ID"
+	AnnotationKeyFrameworkAttemptInstanceUID = "FC_FRAMEWORK_ATTEMPT_INSTANCE_UID"
+	AnnotationKeyConfigMapUID                = "FC_CONFIGMAP_UID"
+	AnnotationKeyTaskAttemptID               = "FC_TASK_ATTEMPT_ID"
 
+	// Predefined Labels
 	LabelKeyFrameworkName = AnnotationKeyFrameworkName
 	LabelKeyTaskRoleName  = AnnotationKeyTaskRoleName
 
 	// For all managed containers
-	EnvNameFrameworkName = AnnotationKeyFrameworkName
-	EnvNameTaskRoleName  = AnnotationKeyTaskRoleName
-	EnvNameTaskIndex     = AnnotationKeyTaskIndex
-	EnvNameConfigMapName = AnnotationKeyConfigMapName
-	EnvNamePodName       = AnnotationKeyPodName
-	EnvNamePodNamespace  = AnnotationKeyPodNamespace
+	// Predefined Environment Variables
+	// It can be referred by the environment variable specified in the spec, i.e.
+	// specify the environment variable value to include "$(AnyPredefinedEnvName)".
+	EnvNameFrameworkNamespace = AnnotationKeyFrameworkNamespace
+	EnvNameFrameworkName      = AnnotationKeyFrameworkName
+	EnvNameTaskRoleName       = AnnotationKeyTaskRoleName
+	EnvNameTaskIndex          = AnnotationKeyTaskIndex
+	EnvNameConfigMapName      = AnnotationKeyConfigMapName
+	EnvNamePodName            = AnnotationKeyPodName
 
 	EnvNameFrameworkAttemptID          = AnnotationKeyFrameworkAttemptID
 	EnvNameFrameworkAttemptInstanceUID = AnnotationKeyFrameworkAttemptInstanceUID
 	EnvNameConfigMapUID                = AnnotationKeyConfigMapUID
 	EnvNameTaskAttemptID               = AnnotationKeyTaskAttemptID
-	EnvNameTaskAttemptInstanceUID      = "TASK_ATTEMPT_INSTANCE_UID"
-	EnvNamePodUID                      = "POD_UID"
+	EnvNameTaskAttemptInstanceUID      = "FC_TASK_ATTEMPT_INSTANCE_UID"
+	EnvNamePodUID                      = "FC_POD_UID"
 )
 
 var FrameworkGroupVersionKind = SchemeGroupVersion.WithKind(FrameworkKind)


### PR DESCRIPTION
1. Change "POD_NAMESPACE" to "FRAMEWORK_NAMESPACE"
2. Prefix "FC_" for all FrameworkController Predefined AnnotationKeys, LabelKeys and EnvNames
3. Prefix "FB_" and uppercase TaskRoleName for all FrameworkBarrier EnvNames