### PR TITLE
Remove deprecated Initializers in planning

### DIFF
--- a/doc/known-issue-and-upcoming-feature.md
+++ b/doc/known-issue-and-upcoming-feature.md
@@ -16,4 +16,3 @@
 - [ ] Support Framework Spec Update
 - [ ] Support Framework Spec Validation and Defaulting
 - [ ] Support Framework Status Subresource
-- [ ] Add AttemptCreating state to move the object initialization time out of the ObjectLocalCacheCreationTimeoutSec

--- a/pkg/apis/frameworkcontroller/v1/constants.go
+++ b/pkg/apis/frameworkcontroller/v1/constants.go
@@ -45,7 +45,7 @@ const (
 	ConfigFilePath                    = "./frameworkcontroller.yaml"
 	UnlimitedValue                    = -1
 	ExtendedUnlimitedValue            = -2
-	LargeFrameworkCompressionMinBytes = 100 * 1024
+	LargeFrameworkCompressionMinBytes = 700 * 1024
 
 	// For all managed objects
 	// Predefined Annotations

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -209,12 +209,6 @@ func NewFrameworkController() *FrameworkController {
 	// Informer resync will periodically replay the event of all objects stored in its cache.
 	// However, by design, Informer and Controller should not miss any event.
 	// So, we should disable resync to avoid hiding missing event bugs inside Controller.
-	//
-	// TODO: Add AttemptCreating state after SharedInformer supports IncludeUninitialized.
-	// So that we can move the object initialization time out of the
-	// ObjectLocalCacheCreationTimeoutSec, to reduce the expectation timeout false alarm
-	// rate when Pod is specified with Initializers.
-	// See https://github.com/kubernetes/kubernetes/pull/51247
 	cmListerInformer := kubeInformer.NewSharedInformerFactory(kClient, 0).Core().V1().ConfigMaps()
 	podListerInformer := kubeInformer.NewSharedInformerFactory(kClient, 0).Core().V1().Pods()
 	fListerInformer := frameworkInformer.NewSharedInformerFactory(fClient, 0).Frameworkcontroller().V1().Frameworks()


### PR DESCRIPTION
Refer: https://github.com/kubernetes/kubernetes/pull/72972