### PR TITLE
Keep podGracefulDeletionTimeoutSec as Nullable

### DIFF
--- a/pkg/apis/frameworkcontroller/v1/crd.go
+++ b/pkg/apis/frameworkcontroller/v1/crd.go
@@ -148,6 +148,7 @@ func buildFrameworkSchema() *apiExtensions.CustomResourceValidation {
 												},
 												"podGracefulDeletionTimeoutSec": {
 													Type: "integer",
+													Nullable: true,
 												},
 												"pod": {
 													Type:                   "object",


### PR DESCRIPTION
Fix #73 which is introduced by #72 